### PR TITLE
added buildscript limesuite

### DIFF
--- a/stage3/10-limesuite/00-packages
+++ b/stage3/10-limesuite/00-packages
@@ -1,0 +1,5 @@
+libi2c-dev
+libusb-1.0-0-dev 
+libwxgtk3.0-dev 
+freeglut3-dev 
+libsqlite3-dev

--- a/stage3/10-limesuite/01-run-chroot.sh
+++ b/stage3/10-limesuite/01-run-chroot.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+function cmakebuild() {
+  pushd $1
+  git checkout stable
+  mkdir builddir
+  pushd builddir
+  cmake ..
+  make -j4
+  make install
+  popd
+  pushd udev-rules
+  ./install.sh
+  popd
+  popd
+  rm -rf $1
+}
+
+
+pushd /tmp
+
+git clone https://github.com/myriadrf/LimeSuite.git
+cmakebuild LimeSuite
+ldconfig
+
+popd


### PR DESCRIPTION
This pull request should add the LimeSuite to the images. This is necessary for support of the LimeNET Micro (https://wiki.myriadrf.org/LimeNET_Micro) I did not test this pull request because I lack the environment but it works on commandline.
Originally the following packages are installed before build:
apt-get install libi2c-dev libusb-1.0-0-dev libwxgtk3.0-dev freeglut3-dev git g++ cmake libsqlite3-dev

Unfortunaatelly I did not yet figure out how to cut out the gui application of the lime suite.

A working config for the lime sdr will follow as soon as I figured out where it is.

